### PR TITLE
THdrFileFormat.SaveData should set true on successful save

### DIFF
--- a/Source/ImagingRadiance.pas
+++ b/Source/ImagingRadiance.pas
@@ -436,6 +436,7 @@ begin
     SaveHeader;
     // Save uncompressed pixels
     SavePixels;
+    Result := True;
   finally
     if MustBeFreed then
       FreeImage(ImageToSave);


### PR DESCRIPTION
Before this PR, HDR saving goes correctly, but `THdrFileFormat.SaveData` result always remains `false`. In effect `TSingleImage.SaveToStream` returns `false`, and the caller things that saving failed.