### PR TITLE
Do not "Assembler Style" = "Intel" in LPK, it breaks compilation on Linux/Arm (like Raspberry Pi)

### DIFF
--- a/Packages/VampyreImagingPackage.lpk
+++ b/Packages/VampyreImagingPackage.lpk
@@ -12,7 +12,6 @@
         <UnitOutputDirectory Value="../Bin/Dcu/$(TargetCPU)-$(TargetOS)/pkg"/>
       </SearchPaths>
       <Parsing>
-        <Style Value="1"/>
         <SyntaxOptions>
           <SyntaxMode Value="Delphi"/>
           <IncludeAssertionCode Value="True"/>


### PR DESCRIPTION
Before this change, `lazbuild` fails to compile the `VampyreImagingPackage.lpk` on Raspberry Pi, with error:

```
Error: (11006) Illegal parameter: -Rintel
```

Compiling package with Lazarus IDE (also on Raspberry Pi) shows the same error. Console confirms that `-Rintel` is used:

```
Info: (lazarus) Param[0]="-Rintel"
Info: (lazarus) Param[1]="-MDelphi"
Info: (lazarus) Param[2]="-Scaghi"
Info: (lazarus) Param[3]="-O2"
Info: (lazarus) Param[4]="-OoREGVAR"
Info: (lazarus) Param[5]="-g"
Info: (lazarus) Param[6]="-gl"
Info: (lazarus) Param[7]="-l"
Info: (lazarus) Param[8]="-vewibq"
Info: (lazarus) Param[9]="-vn-h-"
Info: (lazarus) Param[10]="-Fi/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source"
Info: (lazarus) Param[11]="-Fi/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source/JpegLib"
Info: (lazarus) Param[12]="-Fi/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source/ZLib"
Info: (lazarus) Param[13]="-Fu/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source"
Info: (lazarus) Param[14]="-Fu/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source/JpegLib"
Info: (lazarus) Param[15]="-Fu/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Source/ZLib"
Info: (lazarus) Param[16]="-Fu/home/michalis/installed/fpclazarus/3.2.2-laz2.2.0/lazarus/packager/units/arm-linux"
Info: (lazarus) Param[17]="-Fu/home/michalis/installed/fpclazarus/3.2.2-laz2.2.0/lazarus/components/lazutils/lib/arm-linux"
Info: (lazarus) Param[18]="-Fu/home/michalis/installed/fpclazarus/3.2.2-laz2.2.0/lazarus/components/freetype/lib/arm-linux"
Info: (lazarus) Param[19]="-Fu/home/michalis/installed/fpclazarus/3.2.2-laz2.2.0/lazarus/lcl/units/arm-linux"
Info: (lazarus) Param[20]="-Fu/home/michalis/installed/fpclazarus/3.2.2-laz2.2.0/lazarus/lcl/units/arm-linux/gtk2"
Info: (lazarus) Param[21]="-Fu/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Packages/"
Info: (lazarus) Param[22]="-FU/home/michalis/sources/castle-engine/castle-engine/src/vampyre_imaginglib/src/Bin/Dcu/arm-linux/pkg/"
Info: (lazarus) Param[23]="-dLCL"
Info: (lazarus) Param[24]="-dLCLgtk2"
Info: (lazarus) Param[25]="-dDONT_LINK_EXTRAS"
Info: (lazarus) Param[26]="VampyreImagingPackage.pas"
```

Tested with FPC 3.2.2 and Lazarus 2.2.0.

This setting in LPK seems to be not necessary -- without it, compilation goes OK at least on Linux/Arm (Raspberry Pi) and Linux/x86_64 (Ubuntu on regular desktop).

