### PR TITLE
Do not use LibTiffDelphi units in VampyreImagingPackageExt.lpk -- they are not necessary on Linux, and prevent installing VampyreImagingPackageExt.lpk in Lazarus IDE

### DIFF
--- a/Packages/VampyreImagingPackageExt.lpk
+++ b/Packages/VampyreImagingPackageExt.lpk
@@ -92,22 +92,27 @@
       </Item14>
       <Item15>
         <Filename Value="..\Extensions\LibTiff\ImagingTiffLib.pas"/>
+        <AddToUsesPkgSection Value="False"/>
         <UnitName Value="ImagingTiffLib"/>
       </Item15>
       <Item16>
         <Filename Value="..\Extensions\LibTiff\LibDelphi.pas"/>
+        <AddToUsesPkgSection Value="False"/>
         <UnitName Value="LibDelphi"/>
       </Item16>
       <Item17>
         <Filename Value="..\Extensions\LibTiff\LibJpegDelphi.pas"/>
+        <AddToUsesPkgSection Value="False"/>
         <UnitName Value="LibJpegDelphi"/>
       </Item17>
       <Item18>
         <Filename Value="..\Extensions\LibTiff\LibTiffDelphi.pas"/>
+        <AddToUsesPkgSection Value="False"/>
         <UnitName Value="LibTiffDelphi"/>
       </Item18>
       <Item19>
         <Filename Value="..\Extensions\LibTiff\ZLibDelphi.pas"/>
+        <AddToUsesPkgSection Value="False"/>
         <UnitName Value="ZLibDelphi"/>
       </Item19>
       <Item20>

--- a/Packages/VampyreImagingPackageExt.pas
+++ b/Packages/VampyreImagingPackageExt.pas
@@ -10,10 +10,8 @@ interface
 uses
   ElderImagery, ElderImageryBsi, ElderImageryCif, ElderImageryImg, 
   ElderImagerySky, ElderImageryTexture, ImagingBinary, ImagingCompare, 
-  ImagingExtFileFormats, ImagingJpeg2000, ImagingPcx, ImagingPsd,
-  ImagingTiff, ImagingXpm, ImagingTiffLib, LibDelphi, LibJpegDelphi,
-  LibTiffDelphi, ZLibDelphi, VampyreImagingPackageExtRegister, 
-  LazarusPackageIntf;
+  ImagingExtFileFormats, ImagingJpeg2000, ImagingPcx, ImagingPsd, ImagingTiff, 
+  ImagingXpm, VampyreImagingPackageExtRegister, LazarusPackageIntf;
 
 implementation
 


### PR DESCRIPTION
Problem: `VampyreImagingPackageExt.lpk` on Linux tries to link with `LibTiffDelphi` while it should not (because USE_DYN_LIB is defined).

`ImagingTiffLib.pas` has lines that define `USE_DYN_LIB` on Linux and friends:

```
{$IF Defined(LINUX) or Defined(BSD) or Defined(MACOS)}
  // Use LibTiff dynamic library in Linux/BSD instead of precompiled objects.
  // It's installed on most systems so let's use it and keep the binary smaller.
  // In macOS it's usually not installed but if it is let's use it.
  {$DEFINE USE_DYN_LIB}
{$IFEND}
```

This means that `LibTiffDynLib` unit is used, and `LibTiffDelphi` is ignored (it is not even compiled, if you compile by pointing FPC / CGE build tool at Vampyre paths, without using LPK information).

However, `VampyreImagingPackageExt.lpk` contains the `LibTiffDelphi` and some related units.

This is

1. unnecessary on Linux (since they should be unused, as `USE_DYN_LIB` is defined).

2. causing problems with installing `VampyreImagingPackageExt.lpk` in Lazarus. That is, you cannot rebuild Lazarus IDE if you do "Use->Install" on `VampyreImagingPackageExt.lpk`.

I propose to change the LPK configuration to not add `LibTiffDelphi` and friends to the uses clause in automatic unit `VampyreImagingPackageExt.pas`. This should keep everything working as it was (on platforms that *do* use `LibTiffDelphi`, they can use it, as Lazarus will pass proper paths to FPC).

----

What follows is my lengthy description of AD 2, i.e. why installing `VampyreImagingPackageExt.lpk` in Lazarus is problematic before this patch.

You may want to mostly ignore it :) As `LibTiffDelphi` is not supposed to be used on Linux at all (as you already define USE_DYN_LIB in this case), the exact details why I failed badly to link with `LibTiffDelphi` on Linux probably don't matter.

The problems described below are visible only if you try to install `VampyreImagingPackageExt.lpk` in Lazarus IDE. That is,

- Compilation of `VampyreImagingPackageExt.lpk` goes OK (as it doesn't reach linking, where I experience problems).

- Using `VampyreImagingPackageExt.lpk` in another application, even LCL application, also goes OK (if you don't try to use auto-generated `VampyreImagingPackageExt.pas` package unit). That is because in this case, the application is linked, but in the end it doesn't link with `LibTiffDelphi`.

- However, if you try to rebuild Lazarus IDE with `VampyreImagingPackageExt.lpk`, it will link Lazarus IDE with auto-generated `VampyreImagingPackageExt.pas` unit, thus try to link application with `LibTiffDelphi`.

Why is "installing `VampyreImagingPackageExt.lpk` in Lazarus" even useful?

- While `VampyreImagingPackageExt.lpk` doesn't register anything in Lazarus, but it is a dependency of Castle Game Engine's `castle_base.lpk` (non-LCL code) which in turn is a dependency of `castle_components.lpk` (CGE LCL code, including `TCastleControlBase` -- see https://castle-engine.io/control_on_form ). So in the end, if someone wants to use `TCastleControlBase`, they want to install `VampyreImagingPackageExt.lpk` too in Lazarus IDE.

How it fails:

(Both systems below are Linux/x86_64):

- On recent Debian testing (that uses `libjpeg62-turbo`) I get error at Lazarus IDE linking:

    ```
    Verbose: linker: /usr/bin/ld: ..../Bin/Dcu/x86_64-linux/pkg-ext/ZLibDelphi.o: undefined reference to symbol 'deflateInit_'
    Verbose: linker: /usr/bin/ld: /lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
    ```

    Even though I have `zlib1g-dev` installed.

    Confirmed with FPC 3.2.2 + Lazarus 2.2.0.

- On Ubuntu Ubuntu 21.10 (that uses `libjpeg-dev` in version `8c-2ubuntu8`) it fails earlier, at libjpeg:

    ```
    Verbose: linker: /usr/bin/ld: ..../Bin/Dcu/x86_64-linux/pkg-ext/LibTiffDelphi.o: undefined reference to symbol 'jpeg_write_tables@@LIBJPEG_8.0'
    Verbose: linker: /usr/bin/ld: /lib/x86_64-linux-gnu/libjpeg.so.8: error adding symbols: DSO missing from command line
    ```

    Confirmed with FPC 3.2.2 + Lazarus 2.0.12 and FPC 3.2.2 + Lazarus 2.2.0.

    Ubuntu's `libjpeg-dev` version refers to jpeg API version 8, and searching the Internet libjpeg versions >= 7 are rather controversial, indeed breaking compatibility. ( https://en.wikipedia.org/wiki/Libjpeg , https://lists.fedoraproject.org/pipermail/devel/2013-January/176400.html , https://libjpeg-turbo.org/About/Jpeg-9 , https://sourceforge.net/p/libjpeg-turbo/mailman/message/30359559/ , https://hardwarebug.org/2009/08/04/ijg-is-back/ , https://hardwarebug.org/2010/02/01/ijg-swings-again-and-misses/ ). However Ubuntu users don't have a choice, it seems: while I can install `libjpeg62-dev` (which conflicts and thus removes `libjpeg-dev`, `libjpeg8-dev`) -> but it also removes the GTK 2 `-dev` libraries, which we need to rebuild Lazarus IDE (at least for GTK 2, default backend on Linux). If I want to reinstall `libgdk-pixbuf-xlib-2.0-dev`, `libgtk2.0-dev`, I need to uninstall `libjpeg62-dev` (and install `libjpeg-dev` again).

    I tried a stupid workaround, by just hacking `LibTiffDelphi.pas` and `LibJpegDelphi.pas` and removing missing symbols, starting from `jpeg_write_tables` and `TIFFcallvjpeg_jpeg_write_tables`, moving to more and more symbols. In the end I removed almost all of them...

    ...only to end up with similar error as I had with Debian, error at linking `ZLibDelphi.o`. Even though I have `zlib1g-dev` installed on Ubuntu too.

Note that it was not a problem on Windows. Installing `VampyreImagingPackageExt.lpk` in Lazarus on Windows is fine.
