### PR TITLE
GitHub CI Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,14 @@ jobs:
         run:  |
           # needed for SDL and GL demos
           sudo apt install libsdl1.2-dev -y
+          
           # to build LCL demos with Qt5 backend
-          #sudo apt install libqt5pas-dev -y
-          
-          
+          # sudo apt install libqt5pas-dev -y
+
+          # With current Lazarus + Ubuntu versions we need to get newer libqt5pas release
+          # (https://forum.lazarus.freepascal.org/index.php/topic,65619.msg500216.html#msg500216)
           wget https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
-          sudo apt install ./libqt5pas1_2.15-1_amd64.deb -y 
-          
+          sudo apt install ./libqt5pas1_2.15-1_amd64.deb -y           
           wget https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
           sudo apt install ./libqt5pas-dev_2.15-1_amd64.deb -y 
       - name: Build demos with FPC (Linux)
@@ -59,28 +60,33 @@ jobs:
         run:  |
           cd Demos/ObjectPascal
 
+          # Built for all platforms
           lazbuild --bm="Release" "Benchmark/Bench.lpi"
           lazbuild --bm="Release" "VampConvert/VampConvert.lpi"
-          lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
-          lazbuild --bm="Release" "SDLDemo/SDLDemo.lpi"
-
+          
           if [ "$RUNNER_OS" == "Linux" ]; then                             
+              # For Linux build LCL demos also with Qt5 (just to test that it builds)
               lazbuild --ws=qt5 --bm="Release" "LCLImager/lclimager.lpi"
               lazbuild --ws=qt5 --bm="Release" "ImageBrowser/ImgBrowser.lpi"
           fi
 
           if [ "$RUNNER_OS" != "macOS" ]; then
+              # Build these for non macOS platforms
               lazbuild --bm="Release" "LCLImager/lclimager.lpi"
               lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"              
+              lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
+              lazbuild --bm="Release" "SDLDemo/SDLDemo.lpi"
           fi
 
           if [ "$RUNNER_OS" == "Windows" ]; then
+              # Build D3D demo just for Windows
               lazbuild --bm="Release" "D3DDemo/D3DDemo.lpi"
           fi
 
           if [ "$RUNNER_OS" == "macOS" ]; then
-            lazbuild --ws=cocoa --bm="Release" "LCLImager/lclimager.lpi"
-            lazbuild --ws=cocoa --bm="Release" "ImageBrowser/ImgBrowser.lpi"
+              # For macOS we need to build LCL demos with Cocoa 
+              lazbuild --ws=cocoa --bm="Release" "LCLImager/lclimager.lpi"
+              lazbuild --ws=cocoa --bm="Release" "ImageBrowser/ImgBrowser.lpi"
           fi
       - name: List Demos Bin directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        # currently stable="Lazarus 2.2.2 / FPC 3.2.2" with setup-lazarus@v3.2
+         # currently stable="Lazarus 3.0 / FPC 3.2.2" with setup-lazarus@v3.2.17
         lazarus-versions: [stable]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Lazarus
-        uses: gcarreno/setup-lazarus@v3.2
+        uses: gcarreno/setup-lazarus@v3
         with:
           lazarus-version: ${{ matrix.lazarus-versions }}
       - name: Print Lazarus version
@@ -89,7 +89,7 @@ jobs:
         run:  |
           lazbuild "Packages/VampyreImagingPackage.lpk"
           lazbuild "Packages/VampyreImagingPackageExt.lpk"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts-${{ matrix.operating-system }}-laz-${{ matrix.lazarus-versions }}
           # exclude compiled units etc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,10 @@ jobs:
           lazbuild --bm="Release" "VampConvert/VampConvert.lpi"
 
           if [ "$RUNNER_OS" == "Linux" ]; then
-              lazbuild --ws=qt5 --bm="Release" "LCLImager/lclimager.lpi"
-              lazbuild --ws=qt5 --bm="Release" "ImageBrowser/ImgBrowser.lpi"
+              #lazbuild --ws=qt5 --bm="Release" "LCLImager/lclimager.lpi"
+              #lazbuild --ws=qt5 --bm="Release" "ImageBrowser/ImgBrowser.lpi"
+              lazbuild --bm="Release" "LCLImager/lclimager.lpi"
+              lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"
           fi
 
           if [ "$RUNNER_OS" != "macOS" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
           lazbuild --bm="Release" "Benchmark/Bench.lpi"
           lazbuild --bm="Release" "VampConvert/VampConvert.lpi"
 
-          if [ "$RUNNER_OS" == "Linux" ]; then
-              #lazbuild --ws=qt5 --bm="Release" "LCLImager/lclimager.lpi"
-              #lazbuild --ws=qt5 --bm="Release" "ImageBrowser/ImgBrowser.lpi"
+          if [ "$RUNNER_OS" == "Linux" ]; then              
               lazbuild --bm="Release" "LCLImager/lclimager.lpi"
               lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"
+
+              lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
           fi
 
           if [ "$RUNNER_OS" != "macOS" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,14 @@ jobs:
           # needed for SDL and GL demos
           sudo apt install libsdl1.2-dev -y
           # to build LCL demos with Qt5 backend
-          sudo apt install libqt5pas-dev -y
+          #sudo apt install libqt5pas-dev -y
+          
+          
+          wget https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
+          sudo apt install ./libqt5pas1_2.15-1_amd64.deb -y 
+          
+          wget https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
+          sudo apt install ./libqt5pas-dev_2.15-1_amd64.deb -y 
       - name: Build demos with FPC (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -54,19 +61,17 @@ jobs:
 
           lazbuild --bm="Release" "Benchmark/Bench.lpi"
           lazbuild --bm="Release" "VampConvert/VampConvert.lpi"
+          lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
+          lazbuild --bm="Release" "SDLDemo/SDLDemo.lpi"
 
-          if [ "$RUNNER_OS" == "Linux" ]; then              
-              lazbuild --bm="Release" "LCLImager/lclimager.lpi"
-              lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"
-
-              lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
+          if [ "$RUNNER_OS" == "Linux" ]; then                             
+              lazbuild --ws=qt5 --bm="Release" "LCLImager/lclimager.lpi"
+              lazbuild --ws=qt5 --bm="Release" "ImageBrowser/ImgBrowser.lpi"
           fi
 
           if [ "$RUNNER_OS" != "macOS" ]; then
               lazbuild --bm="Release" "LCLImager/lclimager.lpi"
-              lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"
-              lazbuild --bm="Release" "OpenGLDemo/OpenGLDemo.lpi"
-              lazbuild --bm="Release" "SDLDemo/SDLDemo.lpi"
+              lazbuild --bm="Release" "ImageBrowser/ImgBrowser.lpi"              
           fi
 
           if [ "$RUNNER_OS" == "Windows" ]; then


### PR DESCRIPTION
- updated versions of used actions 
- now uses Lazarus 3
- due to problems with libqt5pas and current Lazarus + Ubuntu we now pull the library from its GitHub releases instead of install with apt
